### PR TITLE
Adding a new prop to expand/collapse filters on load 

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ React component for the schedule filter widget
      level: {label: "Level", values: ["Beginner", "Intermediate"], enabled: false}
    ]
    ```
+
+   **expandedByDefault**    = boolean to set the filters expanded/collapsed on load
    
    **triggerAction**    = method that will take an ACTION and a payload as params and will return a promise.
    Example: `{action: 'UPDATE_FILTER', payload: {type, values}}`

--- a/src/components/filter-group/index.js
+++ b/src/components/filter-group/index.js
@@ -11,9 +11,9 @@ import FilterText from '../filter-text';
 import styles from "./index.module.scss";
 import { FilterTypes } from '../../constants';
 
-export default ({ filter: { label, options, values, freeText, enabled }, colorSource, type, changeFilter }) => {
+export default ({ filter: { label, options, values, freeText, enabled }, colorSource, type, changeFilter, expandedFilters }) => {
 
-    const [isOpen, setIsOpen] = useState(true);
+    const [isOpen, setIsOpen] = useState(expandedFilters === undefined ? true : expandedFilters);
     const [ref, { height }] = useMeasure();
 
     const toggleAnimation = useSpring({
@@ -88,10 +88,10 @@ export default ({ filter: { label, options, values, freeText, enabled }, colorSo
                 return <FilterText value={values} placeholder={`Search ${label}`} onFilterChange={onTextFilterChange} />
             }
             case FilterTypes.CustomOrder: {
-                return <FilterText isNumeric={true} value={values} placeholder={`Search ${label}`} onFilterChange={onTextFilterChange}  />
+                return <FilterText isNumeric={true} value={values} placeholder={`Search ${label}`} onFilterChange={onTextFilterChange} />
             }
             case FilterTypes.Abstract: {
-                return <FilterText value={values} placeholder={`Search ${label}`} onFilterChange={onTextFilterChange}  />
+                return <FilterText value={values} placeholder={`Search ${label}`} onFilterChange={onTextFilterChange} />
             }
             default:
                 return null;
@@ -102,8 +102,8 @@ export default ({ filter: { label, options, values, freeText, enabled }, colorSo
 
     return (
         <div className={styles.wrapper} data-testid="filter-group-wrapper">
-            <button 
-                className={styles.title} 
+            <button
+                className={styles.title}
                 aria-expanded={isOpen}
                 onClick={() => setIsOpen(!isOpen)} data-testid="filter-group-title">
                 <span>{label}</span>

--- a/src/components/filters.js
+++ b/src/components/filters.js
@@ -48,7 +48,7 @@ class Filters extends React.Component {
 
         return Object.entries(filtersWithOptions).map(([type, filter]) => {
             return (
-                <FilterGroup key={type} filter={filter} type={type} colorSource={settings.colorSource} changeFilter={this.triggerFilterChange} />
+                <FilterGroup key={type} filter={filter} type={type} colorSource={settings.colorSource} expandedFilters={settings.expandedByDefault} changeFilter={this.triggerFilterChange} />
             );
         });
     };

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ const filterProps = {
     events: events.filter(ev => ev.id !== 312),
     allEvents: events,
     filters: filters,
+    expandedByDefault: false,
     colorSource: 'track',
     marketingSettings: marketing.colors,
     triggerAction: (action, {type, values}) => {console.log(`${action}: ${type} - ${values}`)},


### PR DESCRIPTION
* new prop to set the filters expanded/collapsed on load

ref: https://tipit.avaza.com/project/view#!tab=task-pane&groupby=MyTaskProject&view=vertical&task=2846806&fileview=grid

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>